### PR TITLE
Update README.md - fix one spelling mistake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Developing a transferable foundation model/system that can *effortlessly* adapt 
 ### :one: Task Transfer Scenarios are Broad
 
 We illustrate and compare CVinW with other settings using a 2D chart in Figure 1, where the space is constructed with two orthogonal dimensions:
-input image distribution and output concept set. The 2D chart is divided into four quadrants, based on how the model evaluation stage is different from model development stage. For any visual recognition problems at different granularity such as image classification, object detection and segmentation, the modeling setup cann be categorized into one of the four settings. We see an emerging trend on moving towards CVinW. Interested in the various pre-trained vision models that move towards CVinW? please check out Section :fire:[``Papers on Task-level Transfer with Pre-trained Models''](#fire-papers-on-task-level-transfer-with-pre-trained-models).
+input image distribution and output concept set. The 2D chart is divided into four quadrants, based on how the model evaluation stage is different from model development stage. For any visual recognition problems at different granularity such as image classification, object detection and segmentation, the modeling setup can be categorized into one of the four settings. We see an emerging trend on moving towards CVinW. Interested in the various pre-trained vision models that move towards CVinW? please check out Section :fire:[``Papers on Task-level Transfer with Pre-trained Models''](#fire-papers-on-task-level-transfer-with-pre-trained-models).
 
 <table>
 <tr>


### PR DESCRIPTION
I have noticed one grammatical mistake in **README** inside section "**Task Transfer Scenarios are Broad**"

"**modeling setup cann be categorized**"  should be  "**modeling setup can be categorized**"

Screenshot-

![Screenshot (128)](https://github.com/Computer-Vision-in-the-Wild/CVinW_Readings/assets/115995339/c28e5589-d073-475f-a34c-cb632b1df055)
